### PR TITLE
Abort migration when tenant is not empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ database tables. You can execute the migrations using this command:
 bundle exec rake scrivito:migrate scrivito:migrate:publish
 ```
 
+Please note, the migrations require the tenant to be empty. If your tenant only contains data
+that is disposable, you can delete your existing tenant and create another one from scratch
+using the dashboard at [scrivito.com](https://scrivito.com/dashboard). The new tenant will
+have new credentials, so you will have to update the configuration file.
+
 ## Example Content
 
 The migrations also generate some example pages so the app is not empty when you first start it. If you want to start with a blank CMS and do your own thing just delete the migration-file:

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ database tables. You can execute the migrations using this command:
 bundle exec rake scrivito:migrate scrivito:migrate:publish
 ```
 
-Please note, the migrations require the tenant to be empty. If your tenant only contains data
-that is disposable, you can delete your existing tenant and create another one from scratch
-using the dashboard at [scrivito.com](https://scrivito.com/dashboard). The new tenant will
-have new credentials, so you will have to update the configuration file.
+Please note that the migrations require the tenant to be empty. If your tenant already
+contains data but is disposable, you can delete it and create another one from scratch using
+the dashboard at [scrivito.com](https://scrivito.com/dashboard). The new tenant comes with
+new credentials, so you will need to update the configuration file.
 
 ## Example Content
 

--- a/scrivito/migrate/20141127102237_generate_seed_content_migration.rb
+++ b/scrivito/migrate/20141127102237_generate_seed_content_migration.rb
@@ -17,7 +17,7 @@ class GenerateSeedContentMigration < ::Scrivito::Migration
 
   def assert_tenant_is_empty
     if Obj.all.to_a.present?
-      fail "The example app expects the tenant to be empty, however, yours "\
+      fail "The example app expects the tenant to be empty, yours, however, "\
         "contains data. Please ensure that your tenant is empty."
     end
   end

--- a/scrivito/migrate/20141127102237_generate_seed_content_migration.rb
+++ b/scrivito/migrate/20141127102237_generate_seed_content_migration.rb
@@ -1,5 +1,6 @@
 class GenerateSeedContentMigration < ::Scrivito::Migration
   def up
+    assert_tenant_is_empty
     homepage = create_homepage
 
     history_blog = create_history_blog
@@ -13,6 +14,13 @@ class GenerateSeedContentMigration < ::Scrivito::Migration
   end
 
   private
+
+  def assert_tenant_is_empty
+    if Obj.all.to_a.present?
+      fail "The example app expects the tenant to be empty, however, yours "\
+        "contains data. Please ensure that your tenant is empty."
+    end
+  end
 
   def random_path_component
     SecureRandom.hex(16)


### PR DESCRIPTION
Some users are trying to use the example app with tenants that already contained a root object (`/`). This meant that example app migration aborted with an unexpected exception.

With this PR the README gets a paragraph explaining that the tenant is expected to be empty and how to reset a tenant using the dashboard. In addition the migration now aborts with meaningful message if the tenant contains data.